### PR TITLE
Updated eslint to version 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@springworks/test-harness": "1.0.5",
     "coveralls": "2.11.4",
-    "eslint": "1.5.1",
+    "eslint": "1.6.0",
     "eslint-config-springworks": "3.1.1",
     "eslint-plugin-mocha": "1.0.0",
     "istanbul": "0.3.21",


### PR DESCRIPTION
:rocket:

eslint just published version 1.6.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 84 commits (ahead by 84, behind by 0).

- [54600a3](https://github.com/eslint/eslint/commit/54600a38baded690821d6efb060c6c51ad18cefe): 1.6.0
- [42f6329](https://github.com/eslint/eslint/commit/42f63295d7af06f2b58cc278b74c36c76fcda0b2): Merge pull request #4003 from aparajita/fix-allman-switch
- [3029787](https://github.com/eslint/eslint/commit/3029787fe292b284a0cd0868d5205ab49a6a83cb): Merge pull request #4019 from rich-hansen/issue4008
- [4cfbd45](https://github.com/eslint/eslint/commit/4cfbd459321fb0cbfa28c20e0a1206b874edf987): Merge pull request #3992 from alberto/issue3946
- [6149816](https://github.com/eslint/eslint/commit/6149816042cae4b7082aeb775ba6c899477bd52f): Fix: cache is basically not working (fixes #4008)
- [fbc8903](https://github.com/eslint/eslint/commit/fbc890378bf39d4a3d7f50dadd8c6abfcc564cd8): Merge pull request #3960 from mysticatea/curly/fix-multi-for-nesting
- [338555e](https://github.com/eslint/eslint/commit/338555e39fd7e4feab05180fbe2250c6295903f5): Merge pull request #4013 from mysticatea/core/fix-crlf
- [4f7709c](https://github.com/eslint/eslint/commit/4f7709c5ff5227bb65ac3e1e54afb3187c8e70c3): Merge pull request #4012 from mysticatea/no-invalid-this/fix-missing-in-node
- [b2b43f4](https://github.com/eslint/eslint/commit/b2b43f4c00b7cc9ec007c106096d85a14a8d1405): Merge pull request #4017 from jvandemo/fix/source-code-fixer
- [77b7b9e](https://github.com/eslint/eslint/commit/77b7b9ec3f4afc9663213d6aa7d42f4466bd350d): Fix: fix undefined source code (fixes #4016)
- [bff4763](https://github.com/eslint/eslint/commit/bff4763be2a3b05519e15d4b570132817ac71c10): Fix: a test failure on Windows (fixes #3968)
- [1355e0b](https://github.com/eslint/eslint/commit/1355e0b0f73369420d0158f58cb1b75c0fde0983): Fix: `no-invalid-this` had been missing globals in node (fixes #3961)
- [9875101](https://github.com/eslint/eslint/commit/9875101ebc8bc7cf9fe57ecd91abfaf12c78fddf): Fix: `curly` with `multi` had false positive (fixes #3856)
- [45863c1](https://github.com/eslint/eslint/commit/45863c1bc2a88103c87c3edcbad2e851b8c0b15b): Merge pull request #3989 from dominicbarnes/ignored-files-should-not-stat
- [fa830ea](https://github.com/eslint/eslint/commit/fa830ea133488376d7c6f96b471048ac2d5b865f): Merge pull request #4005 from eslint/issue3994


There are 84 commits in total. See the [full diff](https://github.com/eslint/eslint/compare/63cd48217b3f2f79b5dfea0c70a90c83cfbd0256...54600a38baded690821d6efb060c6c51ad18cefe).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>