### PR TITLE
Exclude definition of `visibility_timeout` if omitted

### DIFF
--- a/lib/queue/sqs-handler.js
+++ b/lib/queue/sqs-handler.js
@@ -9,7 +9,7 @@
  * @return {Object}          Methods
  */
 exports.create = function(aws_sqs, config, logger) {
-  const visibility_timeout = config.visibility_timeout;
+  const opt_visibility_timeout = config.visibility_timeout;
   const wait_time_seconds = config.wait_time_seconds;
   const attribute_names = config.attribute_names;
   const max_nof_messages = config.max_nof_messages;
@@ -63,13 +63,18 @@ exports.create = function(aws_sqs, config, logger) {
    * @return {Object} Parameters to provide to receiveMessage().
    */
   function getReceiveMessageParams(queue_url) {
-    return {
+    const params = {
       QueueUrl: queue_url,
-      VisibilityTimeout: visibility_timeout,
       WaitTimeSeconds: wait_time_seconds,
       AttributeNames: attribute_names,
       MaxNumberOfMessages: max_nof_messages,
     };
+
+    if (opt_visibility_timeout) {
+      params.VisibilityTimeout = opt_visibility_timeout;
+    }
+
+    return params;
   }
 
 

--- a/test/unit/queue/sqs-handler-test.js
+++ b/test/unit/queue/sqs-handler-test.js
@@ -12,175 +12,204 @@ describe('test/unit/queue/sqs-handler-test.js', () => {
   beforeEach(() => {
     aws_sqs = {};
     logger = {};
+  });
+
+  beforeEach(() => {
     config = test_util.getTestConfig();
   });
 
-  describe('Getting SQS queue URL', () => {
+  describe('with a complete config', () => {
 
-    it('should provide params required to find URL by name', done => {
-      const params = { someparam: 'mockedparam' };
-      const mockdata = { QueueUrl: 'https://www.mock.com' };
+    describe('Getting SQS queue URL', () => {
 
-      aws_sqs.getQueueUrl = sinon.stub();
-      aws_sqs.getQueueUrl.throws('not mocked args')
-          .withArgs(sinon.match.object, sinon.match.func).callsArgWithAsync(1, null, mockdata);
+      it('should provide params required to find URL by name', done => {
+        const params = { someparam: 'mockedparam' };
+        const mockdata = { QueueUrl: 'https://www.mock.com' };
 
-      sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
+        aws_sqs.getQueueUrl = sinon.stub();
+        aws_sqs.getQueueUrl.throws('not mocked args')
+            .withArgs(sinon.match.object, sinon.match.func).callsArgWithAsync(1, null, mockdata);
 
-      sqs_handler.getQueueUrl(params, (err, url) => {
-        should.not.exist(err);
-        url.should.eql('https://www.mock.com');
-        done();
+        sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
+
+        sqs_handler.getQueueUrl(params, (err, url) => {
+          should.not.exist(err);
+          url.should.eql('https://www.mock.com');
+          done();
+        });
+
+      });
+
+      it('should callback with error when error', done => {
+        const params = { someparam: 'mockedparam' };
+
+        aws_sqs.getQueueUrl = sinon.stub();
+        aws_sqs.getQueueUrl.throws('not mocked args')
+            .withArgs(sinon.match.object, sinon.match.func).callsArgWithAsync(1, new Error(), null);
+
+        sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
+
+        sqs_handler.getQueueUrl(params, (err, url) => {
+          should.exist(err);
+          should.not.exist(url);
+          done();
+        });
+
       });
 
     });
 
-    it('should callback with error when error', done => {
-      const params = { someparam: 'mockedparam' };
+    describe('Receiving Message Batch', () => {
 
-      aws_sqs.getQueueUrl = sinon.stub();
-      aws_sqs.getQueueUrl.throws('not mocked args')
-          .withArgs(sinon.match.object, sinon.match.func).callsArgWithAsync(1, new Error(), null);
+      it('should receive message batch', done => {
+        const url = 'queue_url';
+        let expected_params;
 
-      sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
+        expected_params = {
+          QueueUrl: 'http://www.mock.com',
+          VisibilityTimeout: 5,
+          WaitTimeSeconds: 5,
+          AttributeNames: ['All'],
+          MaxNumberOfMessages: 10,
+        };
 
-      sqs_handler.getQueueUrl(params, (err, url) => {
-        should.exist(err);
-        should.not.exist(url);
-        done();
+        logger.debug = sinon.stub().throws('debug not mocked for args')
+            .withArgs('receiveMessageBatch: %s', url).returns();
+
+        aws_sqs.receiveMessage = sinon.stub().throws('aws_sqs not mocked for args')
+            .withArgs(expected_params, sinon.match.func).callsArgWithAsync(1, null, { Message: 'abc123' });
+
+        sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
+
+        sqs_handler.receiveMessageBatch(url, (err, data) => {
+          should.not.exist(err);
+          data.should.eql({ Message: 'abc123' });
+          done();
+        });
+
+      });
+
+      it('should handle error from aws_sqs', done => {
+        const url = 'queue_url';
+        let expected_params;
+
+        expected_params = {
+          QueueUrl: 'http://www.mock.com',
+          VisibilityTimeout: 5,
+          WaitTimeSeconds: 5,
+          AttributeNames: ['All'],
+          MaxNumberOfMessages: 10,
+        };
+
+        logger.debug = sinon.stub().throws('debug not mocked for args')
+            .withArgs('receiveMessageBatch: %s', url).returns();
+
+        aws_sqs.receiveMessage = sinon.stub().throws('aws_sqs not mocked for args')
+            .withArgs(expected_params, sinon.match.func).callsArgWithAsync(1, new Error('banana'), null);
+
+        sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
+
+        sqs_handler.receiveMessageBatch(url, (err, data) => {
+          should.not.exist(data);
+          err.should.be.instanceOf(Error);
+          done();
+        });
+
+      });
+
+    });
+
+    describe('Getting queue url params', () => {
+
+      it('should get the queue url params', () => {
+        let result;
+        const url = 'sqs_url';
+
+        sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
+        result = sqs_handler.getQueueUrlParams(url);
+        result.should.have.ownProperty('QueueName');
+        result.QueueName.should.equal('sqs_url');
+      });
+
+    });
+
+    describe('Getting receive message params', () => {
+
+      it('should get the receive message params', () => {
+        let result;
+        const url = 'sqs_url';
+        const expected_params = {
+          QueueUrl: url,
+          VisibilityTimeout: 5,
+          WaitTimeSeconds: 5,
+          AttributeNames: ['All'],
+          MaxNumberOfMessages: 10,
+        };
+
+        sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
+        result = sqs_handler.getReceiveMessageParams(url);
+        result.should.eql(expected_params);
+      });
+
+    });
+
+    describe('Deleting messages', () => {
+
+      it('should delete messages', done => {
+        const queue_url = 'sqs_url';
+        const receipt_handle = 'receipt_handle';
+
+        aws_sqs.deleteMessage = sinon.stub().throws('aws_sqs not mocked for args')
+            .withArgs({ QueueUrl: queue_url, ReceiptHandle: receipt_handle }, sinon.match.func)
+            .callsArgWithAsync(1, null, { emty: 'data' });
+
+        sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
+
+        sqs_handler.deleteMessage(queue_url, receipt_handle, (err, data) => {
+          should.not.exist(err);
+          should.not.exist(data); // data is also supposed to be null
+          done();
+        });
+      });
+
+      it('should handle error', done => {
+        const queue_url = 'sqs_url';
+        const receipt_handle = 'receipt_handle';
+
+        aws_sqs.deleteMessage = sinon.stub().throws('aws_sqs not mocked for args')
+            .withArgs({ QueueUrl: queue_url, ReceiptHandle: receipt_handle }, sinon.match.func)
+            .callsArgWithAsync(1, new Error('crash'), null);
+
+        sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
+
+        sqs_handler.deleteMessage(queue_url, receipt_handle, (err, data) => {
+          err.should.be.instanceOf(Error);
+          should.not.exist(data); // data is also supposed to be null
+          done();
+        });
       });
 
     });
 
   });
 
-  describe('Receiving Message Batch', () => {
+  describe('omitting optional visibility_timeout option', () => {
 
-    it('should receive message batch', done => {
-      const url = 'queue_url';
-      let expected_params;
-
-      expected_params = {
-        QueueUrl: 'http://www.mock.com',
-        VisibilityTimeout: 5,
-        WaitTimeSeconds: 5,
-        AttributeNames: ['All'],
-        MaxNumberOfMessages: 10,
-      };
-
-      logger.debug = sinon.stub().throws('debug not mocked for args')
-          .withArgs('receiveMessageBatch: %s', url).returns();
-
-      aws_sqs.receiveMessage = sinon.stub().throws('aws_sqs not mocked for args')
-          .withArgs(expected_params, sinon.match.func).callsArgWithAsync(1, null, { Message: 'abc123' });
-
-      sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
-
-      sqs_handler.receiveMessageBatch(url, (err, data) => {
-        should.not.exist(err);
-        data.should.eql({ Message: 'abc123' });
-        done();
-      });
-
+    beforeEach(() => {
+      delete config.visibility_timeout;
     });
 
-    it('should handle error from aws_sqs', done => {
-      const url = 'queue_url';
-      let expected_params;
-
-      expected_params = {
-        QueueUrl: 'http://www.mock.com',
-        VisibilityTimeout: 5,
-        WaitTimeSeconds: 5,
-        AttributeNames: ['All'],
-        MaxNumberOfMessages: 10,
-      };
-
-      logger.debug = sinon.stub().throws('debug not mocked for args')
-          .withArgs('receiveMessageBatch: %s', url).returns();
-
-      aws_sqs.receiveMessage = sinon.stub().throws('aws_sqs not mocked for args')
-          .withArgs(expected_params, sinon.match.func).callsArgWithAsync(1, new Error('banana'), null);
-
-      sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
-
-      sqs_handler.receiveMessageBatch(url, (err, data) => {
-        should.not.exist(data);
-        err.should.be.instanceOf(Error);
-        done();
-      });
-
-    });
-
-  });
-
-  describe('Getting queue url params', () => {
-
-    it('should get the queue url params', () => {
-      let result;
+    it('should not include visibility_timeout in receiveMessage() params', () => {
       const url = 'sqs_url';
+      let params;
 
       sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
-      result = sqs_handler.getQueueUrlParams(url);
-      result.should.have.ownProperty('QueueName');
-      result.QueueName.should.equal('sqs_url');
-    });
-
-  });
-
-  describe('Getting receive message params', () => {
-
-    it('should get the receive message params', () => {
-      let result;
-      const url = 'sqs_url';
-      const expected_params = {
+      params = sqs_handler.getReceiveMessageParams(url);
+      params.should.eql({
         QueueUrl: url,
-        VisibilityTimeout: 5,
         WaitTimeSeconds: 5,
         AttributeNames: ['All'],
         MaxNumberOfMessages: 10,
-      };
-
-      sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
-      result = sqs_handler.getReceiveMessageParams(url);
-      result.should.eql(expected_params);
-    });
-
-  });
-
-  describe('Deleting messages', () => {
-
-    it('should delete messages', done => {
-      const queue_url = 'sqs_url';
-      const receipt_handle = 'receipt_handle';
-
-      aws_sqs.deleteMessage = sinon.stub().throws('aws_sqs not mocked for args')
-          .withArgs({ QueueUrl: queue_url, ReceiptHandle: receipt_handle }, sinon.match.func)
-          .callsArgWithAsync(1, null, { emty: 'data' });
-
-      sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
-
-      sqs_handler.deleteMessage(queue_url, receipt_handle, (err, data) => {
-        should.not.exist(err);
-        should.not.exist(data); // data is also supposed to be null
-        done();
-      });
-    });
-
-    it('should handle error', done => {
-      const queue_url = 'sqs_url';
-      const receipt_handle = 'receipt_handle';
-
-      aws_sqs.deleteMessage = sinon.stub().throws('aws_sqs not mocked for args')
-          .withArgs({ QueueUrl: queue_url, ReceiptHandle: receipt_handle }, sinon.match.func)
-          .callsArgWithAsync(1, new Error('crash'), null);
-
-      sqs_handler = sqs_handler_module.create(aws_sqs, config, logger);
-
-      sqs_handler.deleteMessage(queue_url, receipt_handle, (err, data) => {
-        err.should.be.instanceOf(Error);
-        should.not.exist(data); // data is also supposed to be null
-        done();
       });
     });
 


### PR DESCRIPTION
Exclude definition of `visibility_timeout` if omitted

Ensures that receiveMessage() won't include the param at all if omitted.

It's already optional since before, but this makes the behavior a bit more solid.