### PR TITLE
fix: Make timing logging a bit more clear

### DIFF
--- a/lib/message-capture.js
+++ b/lib/message-capture.js
@@ -45,7 +45,8 @@ exports.create = function(message_queue, message_processing, logger) {
       logger.info(logPayload({
         queue: queue_name,
         count: message_count,
-        duration_seconds: receive_duration_millis / 1000,
+        start_time: start_time,
+        receive_duration_seconds: receive_duration_millis / 1000,
       }), 'Message batch received');
 
       message_processing.processMessages(sqs_messages, queue_name, () => {
@@ -53,7 +54,8 @@ exports.create = function(message_queue, message_processing, logger) {
         logger.info(logPayload({
           queue: queue_name,
           count: message_count,
-          duration_seconds: processing_duration_millis / 1000,
+          start_time: start_time,
+          processing_duration_seconds: processing_duration_millis / 1000,
         }), 'Done processing message batch');
         callback();
       });


### PR DESCRIPTION
fix: Make timing logging a bit more clear

Was confusing that properties had same name in different contexts.