### PR TITLE
fix: Log specific start time for processing instead of total start time

### DIFF
--- a/lib/message-capture.js
+++ b/lib/message-capture.js
@@ -22,7 +22,7 @@ exports.create = function(message_queue, message_processing, logger) {
    * @param {Function} callback Invoked with [err].
    */
   function receiveMessageBatch(queue_name, callback) {
-    const start_time = Date.now();
+    const receive_start_time = Date.now();
     message_queue.receiveQueueMessages(queue_name, (err, sqs_messages) => {
       if (err) {
         err.payload = {
@@ -41,20 +41,22 @@ exports.create = function(message_queue, message_processing, logger) {
         return;
       }
 
-      const receive_duration_millis = Date.now() - start_time;
+      const receive_duration_millis = Date.now() - receive_start_time;
       logger.info(logPayload({
         queue: queue_name,
         count: message_count,
-        start_time: start_time,
+        receive_start_time: new Date(receive_start_time),
         receive_duration_seconds: receive_duration_millis / 1000,
       }), 'Message batch received');
 
+      const processing_start_time = Date.now();
       message_processing.processMessages(sqs_messages, queue_name, () => {
-        const processing_duration_millis = Date.now() - start_time;
+        const processing_duration_millis = Date.now() - processing_start_time;
         logger.info(logPayload({
           queue: queue_name,
           count: message_count,
-          start_time: start_time,
+          receive_start_time: new Date(receive_start_time),
+          processing_start_time: new Date(processing_start_time),
           processing_duration_seconds: processing_duration_millis / 1000,
         }), 'Done processing message batch');
         callback();


### PR DESCRIPTION
This makes it possible to see how long the actual process takes, while still being able to see the total time (including message received).