### PR TITLE
fix: Delay retry request with 1000ms

### DIFF
--- a/lib/sqs-processor.js
+++ b/lib/sqs-processor.js
@@ -65,7 +65,7 @@ exports.create = function(message_capture, timeout_handler, emitter, config, log
       // has been called sice we can't get here if it has
       // then the timeout_handler should be stopped already thus
       // making it impossible to get in here.
-      process.nextTick(receiveNextBatch);
+      setImmediate(receiveNextBatch);
     });
 
     // Start a timer to automatically fetch new batch
@@ -73,17 +73,20 @@ exports.create = function(message_capture, timeout_handler, emitter, config, log
       const local_handled = handled;
       handled = true;
 
-      if (err) {
-        logger.trace(err, 'receiveNextBatch failed');
-      }
-
       // Stop the timeout
       timeout_stop_function();
+
+      if (err) {
+        logger.trace(err, 'receiveNextBatch failed, delaying receiveNextBatch with 1s');
+        setTimeout(receiveNextBatch, 1000);
+        return;
+      }
+
 
       // Make sure that we do not spawn more threads by running
       // both the timeout 'thread' and the done 'thread'
       if (!local_handled) {
-        process.nextTick(receiveNextBatch);
+        setImmediate(receiveNextBatch);
       }
     });
   }


### PR DESCRIPTION
This will lower the number of requests during permission errors or similar to 1 per 1000ms instead
of 1-3 per ms